### PR TITLE
Sample Corpus: Financial Data

### DIFF
--- a/files/fdoc1.txt
+++ b/files/fdoc1.txt
@@ -1,0 +1,25 @@
+Common stock offered by us 6,666,666 shares.
+Common stock offered 12,000,000 shares.
+Common stock offered 15,000,000 shares.
+we are offering 2,000,000 shares of our common stock.
+we are offering 4,500,000 shares.
+Common stock offered 11,000,000 shares.
+We are offering 6,000,000 common units.
+Common stock offered by us 3,977,272 shares.
+Class A common stock offered by us 12,500,000 shares.
+
+Common stock to be outstanding after this offering 12,766,766 shares.
+The underwriters may purchase up to an additional 1,000,000 shares.
+Underwriting discount $1.08.
+The underwriters may also exercise their option to purchase up to an additional 1,159,090 shares.
+Underwriting discount $1.76.
+The date of this prospectus supplement is May 5, 2015.
+The underwriters expect to deliver the shares against payment in New York, New York on March 30, 2011.
+Granted the underwriters an option to purchase up to an additional 750,000 shares.
+Common stock to be outstanding after this offering 67,957,147 shares.
+The underwriters may also exercise their option to purchase up to an additional 1,125,000 shares.
+The shares will be ready for delivery on or about April 14, 2014.
+The date of this prospectus supplement is April 9, 2014.
+The underwriters may also exercise their option to purchase up to an additional 1,650,000 shares.
+The shares will be ready for delivery on or about June 26, 2013.
+The date of this prospectus supplement is June 20, 2013.

--- a/files/fdoc2.txt
+++ b/files/fdoc2.txt
@@ -1,0 +1,13 @@
+Common stock offered by us 12,000,000 shares.
+Common stock offered by us 12,000,000 shares.
+We are selling 10,000,000 units.
+Common stock offered by us 5,400,000 shares.
+We are offering 5,390,000 shares.
+
+Units to be outstanding after this offering(1) 21,626,321 common units and 7,525,000 subordinated units.
+Underwriting discounts and commissions $1.26.
+Underwriting discount $ 0.53625.
+The underwriters may purchase up to an additional 975,000 shares.
+Delivery of the shares of common stock will be made on or about November 19, 2013.
+Units outstanding after this offering 5,913,000 common units and 5,913,000 subordinated units.
+Common stock to be outstanding immediately after this offering 47,289,590 shares.


### PR DESCRIPTION
This pull request adds two new files: `files/fdoc1.txt` and `files/fdoc2.txt` containing a slightly more complicated classification task for "Primary Shares." For simplicity: the lines at the top of each document are the positive examples, whereas the lines at the bottom of the documents are negative examples.

These will not work correctly with the current implementation, running: `python app.py files/fdoc1.txt files/fdoc2.txt` raises the following exception:

```bash
  File "/home/batflyer/research/Textual_Annotation_Interface/app.py", line 227, in learn
    create_files(document,pos_lines)
  File "/home/batflyer/research/Textual_Annotation_Interface/app.py", line 162, in create_files
    positive.append('sentenceContainsTarget(' + mapping[s.replace('.', '')] + ').')
KeyError: 'Common stock offered by us 6,666,666 shares'
```